### PR TITLE
updated wxWidgets.patch

### DIFF
--- a/external/wxWidgets.patch
+++ b/external/wxWidgets.patch
@@ -8,16 +8,3 @@ index 1efa85e255..20ba26ac42 100644
  wx_add_library(wxqa ${QA_FILES})
 -wx_lib_link_libraries(wxqa PUBLIC wxxml)
 +wx_lib_link_libraries(wxqa PUBLIC)
-diff --git a/src/gtk/toplevel.cpp b/src/gtk/toplevel.cpp
-index f4fed8eaa5..0e60a0c7d1 100644
---- a/src/gtk/toplevel.cpp
-+++ b/src/gtk/toplevel.cpp
-@@ -430,7 +430,7 @@ void wxTopLevelWindowGTK::GTKHandleRealized()
-                 if ((m_gdkFunc & GDK_FUNC_CLOSE) == 0)
-                     layout.Replace("close", empty, false);
- 
--                gtk_header_bar_set_decoration_layout(GTK_HEADER_BAR(titlebar), layout);
-+                gtk_header_bar_set_decoration_layout(GTK_HEADER_BAR(titlebar), layout.c_str());
-             }
- #endif // 3.12
-             // Don't set WM decorations when GTK is using Client Side Decorations


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove unused wxxml dependency from wxqa library linking

- Revert GTK header bar decoration layout string conversion patch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["wxWidgets.patch"] -->|Remove wxxml link| B["wxqa library config"]
  A -->|Revert GTK change| C["toplevel.cpp patch"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wxWidgets.patch</strong><dd><code>Remove wxxml dependency and revert GTK patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

external/wxWidgets.patch

<ul><li>Removed <code>wxxml</code> from <code>wx_lib_link_libraries</code> call for wxqa library<br> <li> Deleted entire patch section for <code>src/gtk/toplevel.cpp</code> that converted <br>layout string to c_str()<br> <li> Simplified library linking configuration by removing unused dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/antonvw/wex/pull/1148/files#diff-4e780252b855fcf82c05575a46e9e2318ba5309183463e0d50c1cf7079604e70">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

