### PR TITLE
more vcs  updates

### DIFF
--- a/src/del/frame.cpp
+++ b/src/del/frame.cpp
@@ -2,7 +2,7 @@
 // Name:      frame.cpp
 // Purpose:   Implementation of wex::del::frame class
 // Author:    Anton van Wezenbeek
-// Copyright: (c) 2009-2025 Anton van Wezenbeek
+// Copyright: (c) 2009-2026 Anton van Wezenbeek
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <boost/algorithm/string.hpp>
@@ -996,16 +996,9 @@ bool wex::del::frame::vcs_unified_diff(
   if (auto* stc = dynamic_cast<wex::stc*>(open_file(diff->path_vcs()));
       stc != nullptr)
   {
-    if (diff->is_last())
+    if (diff->type() == factory::unified_diff::diff_t::LAST)
     {
-      if (diff->type() == factory::unified_diff::diff_t::LAST)
-      {
-        stc->diffs().finish(diff);
-        stc->diffs().status();
-        return true;
-      }
-
-      stc->diffs().first();
+      stc->diffs().finish(diff);
       stc->diffs().status();
       return true;
     }

--- a/src/vcs/revisions-dialog.cpp
+++ b/src/vcs/revisions-dialog.cpp
@@ -63,11 +63,9 @@ void rev_data::do_compare()
     m_ve->system(
       process_data(m_data).exe("diff -U0 " + value() + " " + m_repo_path)) == 0)
   {
-    if (vcs_diff("diff"))
-    {
-      unified_diff(path(m_repo_path), m_ve, frame()).parse();
-    }
-    else
+    if (
+      !vcs_diff("diff") ||
+      !unified_diff(path(m_repo_path), m_ve, frame()).parse())
     {
       frame()->open_file_vcs(
         path(m_repo_path + " " + value()),


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor VCS diff logic to use type check instead of is_last method

- Simplify conditional logic in revisions dialog comparison

- Update copyright year to 2026

- Improve error handling in unified diff parsing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["vcs_unified_diff method"] -->|Replace is_last check| B["Use diff type comparison"]
  B -->|Simplify logic| C["Remove redundant condition"]
  D["do_compare method"] -->|Refactor conditional| E["Combine error checks"]
  E -->|Improve readability| F["Single error handling path"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frame.cpp</strong><dd><code>Refactor VCS diff type checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/del/frame.cpp

<ul><li>Update copyright year from 2025 to 2026<br> <li> Replace <code>diff->is_last()</code> method call with direct type comparison <br><code>diff->type() == factory::unified_diff::diff_t::LAST</code><br> <li> Remove redundant nested condition checking the same type<br> <li> Simplify control flow by eliminating unnecessary <code>stc->diffs().first()</code> <br>call</ul>


</details>


  </td>
  <td><a href="https://github.com/antonvw/wex/pull/1154/files#diff-6a4013cc674f24ff6802bbccf33f9c838a64b665cbfa6992ccefc2eb304ea4c2">+3/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>revisions-dialog.cpp</strong><dd><code>Simplify diff comparison error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/vcs/revisions-dialog.cpp

<ul><li>Refactor conditional logic to combine vcs_diff and unified_diff checks<br> <li> Use negation operator to consolidate error conditions into single if <br>block<br> <li> Improve readability by reducing nested conditionals<br> <li> Maintain same error handling behavior with cleaner syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/antonvw/wex/pull/1154/files#diff-ed5564fd97478e24f89c6678f646b2688f6981517ea243afdda630380ecf84bb">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

