### PR TITLE
use shard lib on github action ubuntu

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -94,7 +94,7 @@ jobs:
         run: rm -rf build
 
       - name: Reconfigure and build for artifacts without testing
-        run: ./build-gen.sh -b -g -B ${{steps.install-boost.outputs.BOOST_ROOT}}
+        run: ./build-gen.sh -g -B ${{steps.install-boost.outputs.BOOST_ROOT}}
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
           CC: gcc-14
@@ -106,5 +106,5 @@ jobs:
           name: wex-lib-ubuntu
           path: |
             data/*.*
-            build/**/*.a
+            build/**/*.so
             build/**/setup.h


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove build flag `-b` from build script invocation

- Change artifact upload from static libraries to shared libraries

- Align Ubuntu CI workflow with shared library usage pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Configuration"] -->|Remove -b flag| B["Shared Library Build"]
  C["Artifact Collection"] -->|Change .a to .so| D["Shared Library Artifacts"]
  B --> E["Ubuntu CI Pipeline"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-ubuntu.yml</strong><dd><code>Switch to shared libraries in Ubuntu CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-ubuntu.yml

<ul><li>Removed <code>-b</code> flag from <code>build-gen.sh</code> invocation to disable static library <br>build<br> <li> Changed artifact upload pattern from <code>build/**/*.a</code> to <code>build/**/*.so</code> for <br>shared libraries<br> <li> Maintains boost root configuration and compiler environment variables</ul>


</details>


  </td>
  <td><a href="https://github.com/antonvw/wex/pull/1171/files#diff-87a770b6884e8117dd199cce57508edb045d00580618a51da4763186cf2df461">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

