### PR TITLE
1172 do not re apply patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,16 +51,33 @@ find_package(
 
 set(user $ENV{USER} CACHE INTERNAL "keep user")
 
+# first patch
 execute_process(
-  COMMAND
-    git apply --reverse --check ${CMAKE_SOURCE_DIR}/external/wxWidgets.patch
+  COMMAND git status
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external/wxWidgets
+  OUTPUT_VARIABLE git_STATUS
 )
 
+if(NOT ${git_STATUS} MATCHES "qa/")
+  execute_process(
+    COMMAND git apply ${CMAKE_SOURCE_DIR}/external/wxWidgets.patch
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external/wxWidgets
+  )
+endif()
+
+# second patch
 execute_process(
-  COMMAND git apply --reverse --check ${CMAKE_SOURCE_DIR}/external/lexilla.patch
+  COMMAND git status
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external/wxWidgets/src/stc/lexilla
+  OUTPUT_VARIABLE git_STATUS
 )
+
+if(NOT ${git_STATUS} MATCHES "Lexilla.cxx")
+  execute_process(
+    COMMAND git apply ${CMAKE_SOURCE_DIR}/external/lexilla.patch
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external/wxWidgets/src/stc/lexilla
+  )
+endif()
 
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(external/trompeloeil/include/catch2)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Check git status before applying patches to avoid re-applying

- Add conditional logic to skip patches if already applied

- Verify wxWidgets patch by checking for "qa/" in git status

- Verify lexilla patch by checking for "Lexilla.cxx" in git status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check wxWidgets git status"] --> B{"qa/ found?"}
  B -->|No| C["Apply wxWidgets patch"]
  B -->|Yes| D["Skip wxWidgets patch"]
  E["Check lexilla git status"] --> F{"Lexilla.cxx found?"}
  F -->|No| G["Apply lexilla patch"]
  F -->|Yes| H["Skip lexilla patch"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add conditional patch application with status checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Added git status checks before applying wxWidgets and lexilla patches<br> <li> Wrapped patch application in conditional blocks to prevent <br>re-application<br> <li> Check for "qa/" string in wxWidgets git status output<br> <li> Check for "Lexilla.cxx" string in lexilla git status output</ul>


</details>


  </td>
  <td><a href="https://github.com/antonvw/wex/pull/1177/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

